### PR TITLE
Fix incorrect information in docs/isa.md

### DIFF
--- a/docs/isa.md
+++ b/docs/isa.md
@@ -68,6 +68,10 @@ Each instruction consists of an opcode and operands. The opcode specifies the op
   - Format: `POPG [operand]`
   - Example: `POPG AX`
 
+- **SWP**: Swaps the two halves of a register.
+  - Format: `SWP [operand]`
+  - Example: `SWP AX`
+
 ### Comparison Instructions
 
 - **CMP**: Compares two operands and sets the status register based on the result.
@@ -121,12 +125,6 @@ Each instruction consists of an opcode and operands. The opcode specifies the op
 - **IN**: Inputs a value into the operand.
   - Format: `IN [operand]`
   - Example: `IN AX`
-
-### Stack Instructions
-
-- **SWP**: Swaps the values of two operands.
-  - Format: `SWP [operand1], [operand2]`
-  - Example: `SWP AX, BX`
 
 ## Examples
 


### PR DESCRIPTION
Update `docs/isa.md` to correct the description of the `SWP` instruction.

* **SWP Instruction**:
  - Add the `SWP` instruction under the Data Movement Instructions section.
  - Correct the description to indicate that it swaps the two halves of a register.
  - Provide the format and an example for the `SWP` instruction.
  - Remove the incorrect description of the `SWP` instruction from the Stack Instructions section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/BytesAndCoffee/QuadShot/pull/16?shareId=88fdf11d-9afb-47fd-b91d-116692ac84b7).