### PR TITLE
Fix echo program newline handling

### DIFF
--- a/echo.drip
+++ b/echo.drip
@@ -12,8 +12,11 @@ MAIN:                   ;
   PUSHG CL              ;
   CALL  INPUT           ;
   POPG  BH              ;
+  POPG  AL              ; remove newline from stack
   MOV   CL,text         ;
   ADD   CL,BH           ;
+  MOV   [CL],AL         ; store newline at end
+  DEC   CL              ; point to last char index
 STORE:                  ;
   CMP   BH,0000         ;
   JZ    PRNT            ;


### PR DESCRIPTION
## Summary
- handle newline in `echo.drip`

## Testing
- `python QuadShot.py echo hello`

------
https://chatgpt.com/codex/tasks/task_e_6841eecc1df88324857b885cc7ffced6